### PR TITLE
Input map action "menu" and "inventory" polish.

### DIFF
--- a/COGITO/Components/PlayerInteractionComponent.gd
+++ b/COGITO/Components/PlayerInteractionComponent.gd
@@ -1,17 +1,18 @@
 extends Node3D
 class_name PlayerInteractionComponent
 
+# Signals for UI/HUD use
 signal interaction_prompt(interaction_text : String)
 signal hint_prompt(hint_icon:Texture2D, hint_text: String)
 signal set_use_prompt(use_text:String)
 signal updated_wieldable_data(wieldable_icon:Texture2D, wieldable_text: String)
 
+# Signals for Interaction raycast system
 signal interactive_object_detected(interaction_nodes: Array[Node])
 signal nothing_detected()
 signal started_carrying(interaction_node: Node)
 
 var look_vector : Vector3
-
 var device_id : int = -1  #Used for displaying correct input prompts depending on input device.
 
 ## Raycast3D for interaction check.
@@ -38,7 +39,6 @@ var is_wielding : bool
 func _ready():
 	#for node in wieldable_nodes:
 		#node.hide()
-		
 	object_detected = false
 
 func _process(_delta):

--- a/COGITO/Components/ReadableComponent.gd
+++ b/COGITO/Components/ReadableComponent.gd
@@ -21,16 +21,25 @@ func _ready():
 	label_content.text = readable_content
  
 
-func interact(_player_interaction_component):
+func interact(_player_interaction_component: PlayerInteractionComponent):
 	
 	Audio.play_sound_3d(interact_sound).global_position = self.global_position
 	
 	if is_open:
-		readable_ui.hide()
-		_player_interaction_component.get_parent()._on_resume_movement()
-		is_open = false
+		close(_player_interaction_component)
 	else:
-		_player_interaction_component.get_parent()._on_pause_movement()
-		readable_ui.show()
-		has_been_read.emit()
-		is_open = true
+		open(_player_interaction_component)
+
+
+func open(_player_interaction_component: PlayerInteractionComponent):
+	_player_interaction_component.get_parent().toggled_interface.emit(true)
+	_player_interaction_component.get_parent().menu_pressed.connect(close) #Connecting input action menu to close function.
+	readable_ui.show()
+	has_been_read.emit()
+	is_open = true
+
+func close(_player_interaction_component: PlayerInteractionComponent):
+	readable_ui.hide()
+	_player_interaction_component.get_parent().menu_pressed.disconnect(close)
+	is_open = false
+	_player_interaction_component.get_parent().toggled_interface.emit(false)

--- a/COGITO/DemoScenes/COGITO_01_Demo.tscn
+++ b/COGITO/DemoScenes/COGITO_01_Demo.tscn
@@ -271,7 +271,7 @@ script = ExtResource("16_fg1wi")
 inventory_item = ExtResource("17_nl6sa")
 quantity = 2
 
-[sub_resource type="Resource" id="Resource_i5hgd"]
+[sub_resource type="Resource" id="Resource_nfta4"]
 resource_local_to_scene = true
 script = ExtResource("2_chxar")
 inventory_slots = Array[ExtResource("16_fg1wi")]([SubResource("Resource_wdflo"), SubResource("Resource_hpi7r"), null, null])
@@ -349,7 +349,7 @@ size = Vector3(1.5, 0.01, 1.5)
 [sub_resource type="BoxShape3D" id="BoxShape3D_ht4uj"]
 size = Vector3(100, 3, 100)
 
-[sub_resource type="Resource" id="Resource_efpr2"]
+[sub_resource type="Resource" id="Resource_j8gdw"]
 resource_local_to_scene = true
 script = ExtResource("2_chxar")
 inventory_slots = Array[ExtResource("16_fg1wi")]([null, null, null, null, null, null, null, null])
@@ -1260,7 +1260,7 @@ transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 
 [node name="Chest" parent="INTERACTIVE_OBJECTS" groups=["external_inventory"] instance=ExtResource("14_d7sxi")]
 transform = Transform3D(0.686504, 0, -0.727126, 0, 1, 0, 0.727126, 0, 0.686504, -4.38933, 0.0425703, 5.97176)
 inventory_name = "Chest"
-inventory_data = SubResource("Resource_i5hgd")
+inventory_data = SubResource("Resource_nfta4")
 uses_animation = true
 open_animation = "open"
 
@@ -1621,7 +1621,7 @@ transform = Transform3D(-1, 0, 7.45058e-07, 0, 1, 0, -7.45058e-07, 0, -1, -7.537
 pause_menu = NodePath("../TabMenu")
 player_hud = NodePath("../Player_HUD")
 is_using_sanity = false
-inventory_data = SubResource("Resource_efpr2")
+inventory_data = SubResource("Resource_j8gdw")
 step_height_camera_lerp = 1.5
 
 [node name="Player_HUD" parent="." node_paths=PackedStringArray("player") instance=ExtResource("4_1ofwa")]

--- a/COGITO/EasyMenus/Scenes/tab_menu.tscn
+++ b/COGITO/EasyMenus/Scenes/tab_menu.tscn
@@ -66,10 +66,8 @@ custom_minimum_size = Vector2(500, 500)
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_fonts/font = ExtResource("5_7fnwn")
-current_tab = 1
 
 [node name="Game" type="MarginContainer" parent="Content/TabContainer"]
-visible = false
 layout_mode = 2
 theme_override_constants/margin_left = 0
 theme_override_constants/margin_top = 25
@@ -81,12 +79,14 @@ layout_mode = 2
 size_flags_horizontal = 4
 
 [node name="GameTitle" type="Label" parent="Content/TabContainer/Game/VBoxContainer"]
+visible = false
 layout_mode = 2
 theme_override_font_sizes/font_size = 35
 text = "Game"
 horizontal_alignment = 1
 
 [node name="HSeparator" type="HSeparator" parent="Content/TabContainer/Game/VBoxContainer"]
+visible = false
 layout_mode = 2
 theme_override_constants/separation = 10
 
@@ -127,6 +127,7 @@ text = "Quit"
 script = ExtResource("6_a8sll")
 
 [node name="Gameplay" type="MarginContainer" parent="Content/TabContainer"]
+visible = false
 layout_mode = 2
 focus_neighbor_bottom = NodePath("ScrollContainer/VBoxContainer/InvertYAxisCheckButton")
 theme_override_constants/margin_left = 0
@@ -147,12 +148,14 @@ size_flags_horizontal = 3
 theme_override_constants/separation = 15
 
 [node name="GameplayTitle" type="Label" parent="Content/TabContainer/Gameplay/ScrollContainer/VBoxContainer"]
+visible = false
 layout_mode = 2
 theme_override_font_sizes/font_size = 35
 text = "Gameplay"
 horizontal_alignment = 1
 
 [node name="HSeparator" type="HSeparator" parent="Content/TabContainer/Gameplay/ScrollContainer/VBoxContainer"]
+visible = false
 layout_mode = 2
 theme_override_constants/separation = 10
 
@@ -197,12 +200,14 @@ size_flags_horizontal = 3
 theme_override_constants/separation = 15
 
 [node name="OptionsTitle" type="Label" parent="Content/TabContainer/Graphics/ScrollContainer/VBoxContainer"]
+visible = false
 layout_mode = 2
 theme_override_font_sizes/font_size = 35
 text = "Options"
 horizontal_alignment = 1
 
 [node name="HSeparator" type="HSeparator" parent="Content/TabContainer/Graphics/ScrollContainer/VBoxContainer"]
+visible = false
 layout_mode = 2
 size_flags_vertical = 4
 theme_override_constants/separation = 10
@@ -344,12 +349,14 @@ size_flags_horizontal = 3
 theme_override_constants/separation = 15
 
 [node name="AudioTitle" type="Label" parent="Content/TabContainer/Audio/ScrollContainer/VBoxContainer"]
+visible = false
 layout_mode = 2
 theme_override_font_sizes/font_size = 35
 text = "Audio"
 horizontal_alignment = 1
 
 [node name="HSeparator" type="HSeparator" parent="Content/TabContainer/Audio/ScrollContainer/VBoxContainer"]
+visible = false
 layout_mode = 2
 theme_override_constants/separation = 10
 
@@ -412,6 +419,7 @@ text = "Coming soon"
 horizontal_alignment = 1
 
 [node name="HSeparator" type="HSeparator" parent="Content/TabContainer/Bindings/ScrollContainer/VBoxContainer"]
+visible = false
 layout_mode = 2
 theme_override_constants/separation = 10
 

--- a/COGITO/Readme.md
+++ b/COGITO/Readme.md
@@ -1,7 +1,7 @@
 ![COGITO_banner](https://github.com/Phazorknight/Cogito/assets/70389309/dd5060b1-a28e-40c1-8253-3a7e3e4bc116)
 # COGITO
 By Philip Drobar
-Version: **BETA 202402.15**
+Version: **BETA 202402.16**
 Runs on Godot **4.2.1 stable**
 
 COGITO is a first Person Immersive Sim Template Project for Godot Engine 4.

--- a/COGITO/Scripts/Cogito_Keypad.gd
+++ b/COGITO/Scripts/Cogito_Keypad.gd
@@ -67,14 +67,24 @@ func _ready():
 func interact(_player_interaction_component):
 	player_interaction_component = _player_interaction_component
 	if is_open:
-		keypad_ui.hide()
-		_player_interaction_component.get_parent()._on_resume_movement()
-		is_open = false
+		close(_player_interaction_component)
 	else:
-		_player_interaction_component.get_parent()._on_pause_movement()
-		keypad_ui.show()
-		grab_focus_button.grab_focus()
-		is_open = true
+		open(_player_interaction_component)
+
+
+func open(_player_interaction_component):
+	_player_interaction_component.get_parent().toggled_interface.emit(true)
+	_player_interaction_component.get_parent().menu_pressed.connect(close) #Connecting input action menu to close function.
+	keypad_ui.show()
+	grab_focus_button.grab_focus()
+	is_open = true
+	
+	
+func close(_player_interaction_component):
+	keypad_ui.hide()
+	_player_interaction_component.get_parent().menu_pressed.disconnect(close)
+	_player_interaction_component.get_parent().toggled_interface.emit(false)
+	is_open = false
 
 
 func _on_button_received(_passed_string:String):
@@ -133,9 +143,8 @@ func unlock_keypad():
 			if open_when_unlocked:
 				door.open_door(player_interaction_component)
 	
-	keypad_ui.hide()
-	player_interaction_component.get_parent()._on_resume_movement()
-	is_open = false
+	close(player_interaction_component)
+	
 
 func clear_entered_code():
 	entered_code = ""


### PR DESCRIPTION
This update cleans up some of the behaviour of the "menu" and "inventory" input map actions.
- "menu" aka ESC now exits out of any currently active interface.
- "inventory" can no longer be opened while other interfaces are active.
- Interaction Prompts get hidden when any interface is visible.